### PR TITLE
Remove classifier from request

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,6 @@ import {
   SamplerParameters,
   TransformType,
   StepParameter,
-  ClassifierParameters,
   Answer,
   ArtifactType,
 } from 'stability-sdk/gooseai/generation/generation_pb'
@@ -142,8 +141,6 @@ export const generate: (
 
   request.setImage(image)
 
-  const classifier = new ClassifierParameters()
-  request.setClassifier(classifier)
   /** End Build Request **/
 
   if (debug) {


### PR DESCRIPTION
The latest generation.proto removes support for sending a classifier along with the ImageParameters in the request. This should fix the error reported here https://github.com/Stability-AI/stability-sdk/issues/7#issuecomment-1255611624